### PR TITLE
bump dep versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16]
 
     steps:
     - name: Checkout repository
@@ -33,7 +33,7 @@ jobs:
       run: echo "::set-output name=dir::$(npm config get cache)"
 
     - name: Cache dependencies
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v3
       id: npm-cache
       with:
         path: ${{ steps.npm-cache-dir-path.outputs.dir }}
@@ -55,4 +55,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage/coverage-final.json
-
+SSS

--- a/package.json
+++ b/package.json
@@ -63,25 +63,25 @@
         ]
     },
     "devDependencies": {
-        "@rollup/plugin-commonjs": "^22.0.0",
-        "@rollup/plugin-node-resolve": "^13.1.3",
-        "@rollup/plugin-replace": "^4.0.0",
-        "@rollup/plugin-typescript": "^8.3.1",
-        "@types/jest": "^27.4.0",
-        "@types/node": "^18.0.1",
-        "@typescript-eslint/eslint-plugin": "^5.14.0",
-        "@typescript-eslint/parser": "^5.14.0",
-        "concurrently": "^7.0.0",
-        "eslint": "^8.10.0",
-        "husky": "^8.0.1",
-        "jest": "^27.4.7",
-        "lint-staged": "^13.0.0",
-        "prettier": "^2.5.1",
-        "rollup": "^2.70.0",
-        "ts-jest": "^27.1.3",
-        "typescript": "^4.6"
+        "@rollup/plugin-commonjs": "^23.0.7",
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-replace": "^5.0.2",
+        "@rollup/plugin-typescript": "^10.0.1",
+        "@types/jest": "^29.2.4",
+        "@types/node": "^18.11.16",
+        "@typescript-eslint/eslint-plugin": "^5.46.1",
+        "@typescript-eslint/parser": "^5.46.1",
+        "concurrently": "^7.6.0",
+        "eslint": "^8.30.0",
+        "husky": "^8.0.2",
+        "jest": "^29.3.1",
+        "lint-staged": "^13.1.0",
+        "prettier": "^2.8.1",
+        "rollup": "^3.7.5",
+        "ts-jest": "^29.0.3",
+        "typescript": "^4.9.4"
     },
     "dependencies": {
-        "node-ray": "^1.18.0"
+        "node-ray": "^1.19.4"
     }
 }


### PR DESCRIPTION
This PR bumps the versions of all dependencies to their latest. It also removes support for node 12.