### PR TITLE
RayPlugin was not exported

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { VueRay, ray } from '@/VueRay';
 import { RayMixin } from '@/RayMixin';
+import { RayPlugin } from '@/RayPlugin';
 import { initializeOptions } from '@/InitializeOptions';
 import { raySetup } from '@/setup';
 
-export { VueRay, ray, RayMixin, initializeOptions, raySetup };
+export { VueRay, ray, RayMixin, RayPlugin, initializeOptions, raySetup };


### PR DESCRIPTION
I was following the tutorial in your README.md file, but I got an error from my IDE saying that RayPlugin was not found in vue-ray, I checked your index.ts and noticed that it wasn't imported and exported, so I created this PR where I simply proceeded as you've done with RayMixin.

I would like to add tests to my PR, but noticed that there are no tests regarding the exposure of parts, so I decided to open the PR even without tests, if they are needed, I will try to implement them.